### PR TITLE
Run as the nobody user/group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,9 @@ COPY app/ .
 
 COPY ./docker-entrypoint.sh .
 ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# Use the nobody user's numeric UID/GID to satisfy MustRunAsNonRoot PodSecurityPolicies
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
+USER 65534:65534
+
 CMD ["kopf-k8s-sidecar"]


### PR DESCRIPTION
- Run as nobody:nobody to match the permissions used by the upstream
k8s-sidecar. This should avoid any new (and nasty) permission issues