### PR TITLE
Remove finalizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ rbac:
 +      resources: ["configmaps", "secrets"]
 +      verbs: ["patch"]
 ```
-This is because the operator needs to `patch` the resources to add finalizers, see the [Resource deletion](#resource-deletion) section to learn more.
+The operator needs to `patch` resources to add a `kopf.zalando.org/last-handled-configuration` annotation which is used to handle [change detection](https://kopf.readthedocs.io/en/stable/configuration/?highlight=last-handled-configuration#change-detection).
 
 ## Configuration Environment Variables
 
@@ -81,21 +81,3 @@ This is because the operator needs to `patch` the resources to add finalizers, s
 Contrary to the original k8s-sidecar, we will look in `ALL` namespaces by default as documented in the [Configuration Environment Variables](#configuration-environment-variables) section.
 
 If you only want to look for resources in the namespace where the sidecar is installed, feel free to specify it.
-
-### Resource deletion
-
-With the usage of k8s operators, we have access to [finalizers](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers)
-
-Finalizers allow controllers (which operators are a subset of) to perform given actions on a resource before it is garbage collected by Kubernetes.
-
-In our case, that action is to remove previously created files when a `ConfigMap` or `Secret` is deleted.
-
-Finalizers are added to ensure this task is performed by the operator.
-
-Therefore...
-
-**If the operator is down, resources managed by it won't be able to be deleted.**
-
-To resolve this, simply restart the operator container or patch the finalizers out of the resource that you want to forcibly remove.
-
-This is documented by the [kopf](https://kopf.readthedocs.io/en/latest/troubleshooting/#kubectl-freezes-on-object-deletion) framework as well.

--- a/app/conditions.py
+++ b/app/conditions.py
@@ -28,3 +28,7 @@ def resource_is_desired(body, **_):
     kind = body['kind'].lower()
 
     return resource in (kind, 'both')
+
+def resource_is_deleted(event, **_):
+    """Returns true if the resource was deleted in the on.event handler"""
+    return event['type'] == 'DELETED'

--- a/app/sidecar.py
+++ b/app/sidecar.py
@@ -4,7 +4,7 @@ import threading
 import contextlib
 from misc import *
 from io_helpers import write_file, delete_file
-from conditions import label_is_satisfied, resource_is_desired
+from conditions import label_is_satisfied, resource_is_desired, resource_is_deleted
 from list_mode import one_run
 import kopf
 
@@ -52,8 +52,8 @@ def startup_tasks(settings: kopf.OperatorSettings, logger, **_):
 def cru_fn(body, reason, logger, **_):
     write_file(reason, body, body['kind'], logger)
 
-@kopf.on.delete('', 'v1', 'configmaps', when=kopf.all_([label_is_satisfied, resource_is_desired]))
-@kopf.on.delete('', 'v1', 'secrets', when=kopf.all_([label_is_satisfied, resource_is_desired]))
+@kopf.on.event('', 'v1', 'configmaps', when=kopf.all_([label_is_satisfied, resource_is_desired, resource_is_deleted]))
+@kopf.on.event('', 'v1', 'secrets', when=kopf.all_([label_is_satisfied, resource_is_desired, resource_is_deleted]))
 def delete_fn(body, logger, **_):
     delete_file(body, body['kind'], logger)
 


### PR DESCRIPTION
Removed the usage of finalizers to avoid some nasty resource-deleting ordering problems with 3rdparty Helm charts that may use this image.