### PR TITLE
Use only on.event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,6 @@ If you are looking to use this image with the [Grafana Helm chart](https://githu
 * Set `.Values.sidecar.image.repository` to `omegavveapon/kopf-k8s-sidecar` 
 * Set `.Values.sidecar.image.tag` to the latest tag in [Releases](https://github.com/OmegaVVeapon/kopf-k8s-sidecar/releases)
 
-### RBAC permissions
-
-Provide `patch` permissions for `configmaps` and `secrets` in the `values.yaml`
-
-```
-rbac:
--  extraClusterRoleRules: []
-+  extraClusterRoleRules:
-+    - apiGroups: [""]  # "" indicates the core API group
-+      resources: ["configmaps", "secrets"]
-+      verbs: ["patch"]
-```
-The operator needs to `patch` resources to add a `kopf.zalando.org/last-handled-configuration` annotation which is used to handle [change detection](https://kopf.readthedocs.io/en/stable/configuration/?highlight=last-handled-configuration#change-detection).
-
 ## Configuration Environment Variables
 
 | Variable | Required? | Default | Description |

--- a/app/conditions.py
+++ b/app/conditions.py
@@ -24,6 +24,10 @@ def resource_is_desired(body, **_):
 
     return sidecar_settings.RESOURCE in (kind, 'both')
 
+def resource_is_cru(event, **_):
+    """Returns true if the resource was created, resumed or updated in the on.event handler"""
+    return not resource_is_deleted(event)
+
 def resource_is_deleted(event, **_):
     """Returns true if the resource was deleted in the on.event handler"""
     return event['type'] == 'DELETED'

--- a/app/io_helpers.py
+++ b/app/io_helpers.py
@@ -67,11 +67,11 @@ def delete_file(body, kind, logger):
 
     for filename in body['data'].keys():
         filepath = get_filepath(filename, folder, kind, body)
-        logger.info("[DELETE:%s] Deleting file %s.", kind, filepath)
+        logger.info("[DELETED:%s] Deleting file %s.", kind, filepath)
         try:
             os.remove(filepath)
         except FileNotFoundError:
-            logger.error("[DELETE:%s] %s not found.", kind, filepath)
+            logger.error("[DELETED:%s] %s not found.", kind, filepath)
         except OSError as e:
             logger.error(e)
 
@@ -79,7 +79,10 @@ def write_file(event, body, kind, logger):
     """
     Write contents to the desired filepath if they have changed.
     """
-    event = event.upper()
+    if event is None:
+        event = 'RESUMED'
+    else:
+        event = event.upper()
 
     folder = get_folder(body['metadata'])
     create_folder(folder, logger)

--- a/examples/rbac.yaml
+++ b/examples/rbac.yaml
@@ -6,14 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
-    verbs: ["get", "watch", "list", "patch"]
-  # Framework: posting the events about the handlers progress/errors.
-  # - apiGroups: [events.k8s.io]
-  #   resources: [events]
-  #   verbs: [create]
-  # - apiGroups: [""]
-  #   resources: [events]
-  #   verbs: [create]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
- To run in a completely silent mode, switching to only use `on.event`
handlers. No more annotations will be added to the configmaps/secrets.
- Updated README to remove the need for `PATCH` RBAC