### PR TITLE
Watch mode robustness

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-kopf = "==1.32.1"
+kopf = "==1.34.0"
 pykube-ng = "*"
 tenacity = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "510ddb94aaca5978d6be6e99ceae775417e304e9c38a770f56928a33fb58fea9"
+            "sha256": "192a0e0f2f80eeff2c72d17d0f0c0eb175593e5ebd4ecfac47b32eab6314ce3d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -98,6 +98,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6",
+                "sha256:5ec46d183433dcbd0ab716f2d7f29d8dee50505b3fdb40c6b985c7c4f5a3591f"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.6"
+        },
         "click": {
             "hashes": [
                 "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
@@ -108,26 +116,26 @@
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.10"
+            "markers": "python_version >= '3'",
+            "version": "==3.2"
         },
         "iso8601": {
             "hashes": [
-                "sha256:8aafd56fa0290496c5edbb13c311f78fa3a241f0853540da09d9363eae3ebd79",
-                "sha256:e7e1122f064d626e17d47cd5106bed2c620cb38fe464999e0ddae2b6d2de6004"
+                "sha256:36532f77cc800594e8f16641edae7f1baf7932f05d8e508545b95fc53c6dc85b",
+                "sha256:906714829fedbc89955d52806c903f2332e3948ed94e31e85037f9e0226b8376"
             ],
-            "version": "==0.1.14"
+            "version": "==0.1.16"
         },
         "kopf": {
             "hashes": [
-                "sha256:44802deb09245e34dc43106e339a206fcbb8758e49c17580b838e745d6387251",
-                "sha256:5a1bb08adf6efe72b7e6fae26d39ed5738af382370f9d3f2abb537a4af35ee1f"
+                "sha256:a281c7b4e6bf5b50d1a573ef81ae21f7a23dd3c1fe96ff996c1f1e8fb176e6f4",
+                "sha256:df5c7e772a8b731964bd988dd3ee813707ba9054bf3160a72a0ac77e4d70c1d5"
             ],
             "index": "pypi",
-            "version": "==1.32.1"
+            "version": "==1.34.0"
         },
         "multidict": {
             "hashes": [
@@ -182,10 +190,11 @@
         },
         "python-json-logger": {
             "hashes": [
-                "sha256:f26eea7898db40609563bed0a7ca11af12e2a79858632706d835a0f961b7d398"
+                "sha256:202a4f29901a4b8002a6d1b958407eeb2dd1d83c18b18b816f5b64476dde9096",
+                "sha256:99310d148f054e858cd5f4258794ed6777e7ad2c3fd7e1c1b527f1cba4d08420"
             ],
-            "markers": "python_version >= '3.4'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.2"
         },
         "pyyaml": {
             "hashes": [
@@ -224,43 +233,35 @@
         },
         "requests": {
             "hashes": [
-                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.25.1"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.26.0"
         },
         "tenacity": {
             "hashes": [
-                "sha256:5bd16ef5d3b985647fe28dfa6f695d343aa26479a04e8792b9d3c8f49e361ae1",
-                "sha256:a0ce48587271515db7d3a5e700df9ae69cce98c4b57c23a4886da15243603dd8"
+                "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f",
+                "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"
             ],
             "index": "pypi",
-            "version": "==7.0.0"
+            "version": "==8.0.1"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
+                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
+                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
-            "version": "==3.10.0.0"
+            "version": "==3.10.0.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.7"
         },
         "yarl": {
             "hashes": [
@@ -309,11 +310,11 @@
     "develop": {
         "configargparse": {
             "hashes": [
-                "sha256:afbd2823d29ed30cbd53513ea8290938e3dc3136ad9cfffdc684c9225c19adc5",
-                "sha256:dded3590373b7dae6ce6d0afeb4ae3def74761fdd78730952863914d4cb4bdb5"
+                "sha256:c39540eb4843883d526beeed912dc80c92481b0c13c9787c91e614a624de3666",
+                "sha256:f75b235a13dba6692ee9e019470e7bce41861d09606c39c41facb347c24ca3cf"
             ],
             "index": "pypi",
-            "version": "==1.5"
+            "version": "==1.5.2"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ If you are looking to use this image with the [Grafana Helm chart](https://githu
 * Set `.Values.sidecar.image.repository` to `omegavveapon/kopf-k8s-sidecar` 
 * Set `.Values.sidecar.image.tag` to the latest tag in [Releases](https://github.com/OmegaVVeapon/kopf-k8s-sidecar/releases)
 
+### Healthcheck
+
+The sidecar offers a simple healthcheck endpoint for use in a liveness probe (don't use it for readiness is it makes no sense for an operator).
+
+```
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+```
+
 ## Configuration Environment Variables
 
 | Variable | Required? | Default | Description |

--- a/app/sidecar.py
+++ b/app/sidecar.py
@@ -42,11 +42,8 @@ def kopf_thread(
     asyncio.set_event_loop(loop)
     with contextlib.closing(loop):
 
-        # The Grafana Helm chart doesn't even use liveness probes for the sidecar... worth enabling?
-        # liveness_endpoint = "http://0.0.0.0:8080/healthz"
-
         opts = {
-            "liveness_endpoint": None,
+            "liveness_endpoint": "http://0.0.0.0:8080/healthz",
             "clusterwide": False,
             "namespaces": [],
             "ready_flag": ready_flag,

--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -20,10 +20,6 @@ spec:
         - name: datasource-sidecar
           imagePullPolicy: Always
           image: omegavveapon/kopf-k8s-sidecar
-          # livenessProbe:
-          #   httpGet:
-          #     path: /healthz
-          #     port: 8080
           volumeMounts:
             - name: shared-volume
               mountPath: /tmp/
@@ -38,16 +34,14 @@ spec:
               value: "annotation-path"
             - name: LABEL
               value: "fake-datasource"
-            - name: LABEL_VALUE
-              value: "yea"
+            # - name: LABEL_VALUE
+            #   value: "yea"
             - name: FOLDER
               value: /tmp/
             - name: RESOURCE
               value: both
             - name: DEBUG
               value: "false"
-            # - name: LIVENESS
-            #   value: "false"
       containers:
         - name: bash
           image: bash:4.4.19
@@ -59,24 +53,24 @@ spec:
         - name: dashboard-sidecar
           imagePullPolicy: Always
           image: omegavveapon/kopf-k8s-sidecar
-          # livenessProbe:
-          #   httpGet:
-          #     path: /healthz
-          #     port: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
           volumeMounts:
             - name: shared-volume
               mountPath: /tmp/
           env:
             - name: UNIQUE_FILENAMES
               value: "true"
-            # - name: NAMESPACE
-            #   value: test-namespace,default
+            - name: NAMESPACE
+              value: test-namespace
             # - name: METHOD
             #   value: "LIST"
             - name: LABEL
               value: "fake-dashboard"
-            - name: LABEL_VALUE
-              value: "yea"
+            # - name: LABEL_VALUE
+            #   value: "yea"
             - name: FOLDER
               value: /tmp/
             # - name: FOLDER_ANNOTATION
@@ -85,8 +79,6 @@ spec:
               value: both
             - name: DEBUG
               value: "false"
-            # - name: LIVENESS
-            #   value: "false"
       volumes:
         - name: shared-volume
           emptyDir: {}


### PR DESCRIPTION
Fixes #21 .

- Bump to kopf `1.34.0` to benefit from some fixes made for api-retries on connection errors as well as rare issues that can sometimes occur during the operator's startup.
- Enabled the healthcheck endpoint

 