### PR TITLE
Code refactor leveraging the os.path.join intelligence

### DIFF
--- a/app/io_helpers.py
+++ b/app/io_helpers.py
@@ -41,10 +41,7 @@ def get_folder(metadata):
 
     if sidecar_settings.FOLDER_ANNOTATION in annotations:
         folder_annotation = annotations[sidecar_settings.FOLDER_ANNOTATION]
-        if os.path.isabs(folder_annotation):
-            folder = folder_annotation
-        else:
-            folder = os.path.join(folder, folder_annotation)
+        folder = os.path.join(folder, folder_annotation)
 
     return folder
 


### PR DESCRIPTION
- From docs: "If a component is an absolute path, all previous components are
  thrown away and joining continues from the absolute path component."
  Thanks to @guoyiang for pointing this out