### PR TITLE
Alpine update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY Pipfile .
 COPY Pipfile.lock .
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --ignore-pipfile --deploy
 
-FROM python:3.8-alpine AS runtime
+FROM python:3.8-alpine3.15 AS runtime
 
 # Copy virtual env from python-deps stage
 COPY --from=python-deps /.venv /.venv


### PR DESCRIPTION
- Bumping to `python:3.8-alpine3.15` as the runtime image.
- Adding Dependabot to help keep things updated